### PR TITLE
Support latest Container Instance REST API

### DIFF
--- a/aci.ts
+++ b/aci.ts
@@ -2,14 +2,14 @@ import resource = require('./resource');
 
 export function ListContainerGroups(resourceClient): Promise<Array<Object>> {
     let resourceType = 'Microsoft.ContainerInstance/containerGroups'
-    let apiVersion = '2017-04-01-preview'
+    let apiVersion = '2017-08-01-preview'
 
     return resource.getMatchingResources(resourceClient, resourceType, apiVersion);
 }
 
 export function DeleteContainerGroup(id, resourceClient): Promise<Object> {
     let resourceType = 'Microsoft.ContainerInstance/containerGroups'
-    let apiVersion = '2017-04-01-preview'
+    let apiVersion = '2017-08-01-preview'
 
     return resource.deleteResource(resourceClient, id, apiVersion);
 }

--- a/aci.ts
+++ b/aci.ts
@@ -1,14 +1,14 @@
 import resource = require('./resource');
 
 export function ListContainerGroups(resourceClient): Promise<Array<Object>> {
-    let resourceType = 'Microsoft.Container/containerGroups'
+    let resourceType = 'Microsoft.ContainerInstance/containerGroups'
     let apiVersion = '2017-04-01-preview'
 
     return resource.getMatchingResources(resourceClient, resourceType, apiVersion);
 }
 
 export function DeleteContainerGroup(id, resourceClient): Promise<Object> {
-    let resourceType = 'Microsoft.Container/containerGroups'
+    let resourceType = 'Microsoft.ContainerInstance/containerGroups'
     let apiVersion = '2017-04-01-preview'
 
     return resource.deleteResource(resourceClient, id, apiVersion);

--- a/synchronizer.ts
+++ b/synchronizer.ts
@@ -72,7 +72,7 @@ export async function Synchronize(client: api.Core_v1Api, startTime: Date, rsrcC
                 location: "westus"
             }
             await rsrcClient.resources.createOrUpdate(resourceGroup,
-                "Microsoft.Container", "",
+                "Microsoft.ContainerInstance", "",
                 "containerGroups", pod.metadata.name,
                 '2017-04-01-preview', group, (err, result, request, response) => {
                     if (err) {

--- a/synchronizer.ts
+++ b/synchronizer.ts
@@ -74,7 +74,7 @@ export async function Synchronize(client: api.Core_v1Api, startTime: Date, rsrcC
             await rsrcClient.resources.createOrUpdate(resourceGroup,
                 "Microsoft.ContainerInstance", "",
                 "containerGroups", pod.metadata.name,
-                '2017-04-01-preview', group, (err, result, request, response) => {
+                '2017-08-01-preview', group, (err, result, request, response) => {
                     if (err) {
                         console.log(err);
                     } else {

--- a/synchronizer.ts
+++ b/synchronizer.ts
@@ -52,7 +52,13 @@ export async function Synchronize(client: api.Core_v1Api, startTime: Date, rsrcC
                         name: container.name,
                         properties: {
                             ports: ports,
-                            image: container.image
+                            image: container.image,
+                            resources: {
+                                requests: {
+                                    cpu: 1,
+                                    memoryInGB: 1.5
+                                }
+                            }
                         }
                     }
                 );


### PR DESCRIPTION
aci-connector published on Docker Hub will result in an error that does not exist. New Resource Provider and API are supported.

The image of the aci-connector built for the test is released on the Docker Hub.
https://hub.docker.com/r/shibayan/aci-connector-k8s/