### PR TITLE
Updated examples/aci-connector.yaml to use Deployment instead of pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Edit the `examples/aci-connector.yaml` and put the name of the resource group in
 
 ```console
 $ kubectl create -f examples/aci-connector.yaml 
-pod "aci-connector" created
+deployment "aci-connector" created
 
 $ kubectl get nodes -w
 NAME                        STATUS                     AGE       VERSION
@@ -108,7 +108,7 @@ pod "nginx" created
 
 $ kubectl get po -w -o wide
 NAME          READY     STATUS    RESTARTS   AGE       IP             NODE
-aci-connector 1/1       Running   0          44s       10.244.2.21    k8s-agentpool1-31868821-2
+aci-connector-3396840456-v75q2  1/1       Running   0          44s       10.244.2.21    k8s-agentpool1-31868821-2
 nginx         1/1       Running   0          31s       13.88.27.150   aci-connector
 ```
 

--- a/examples/aci-connector.yaml
+++ b/examples/aci-connector.yaml
@@ -1,21 +1,27 @@
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: aci-connector
   namespace: default
 spec:
-  containers:
-  - name: aci-connector
-    image: microsoft/aci-connector-k8s:latest
-    imagePullPolicy: Always
-    env:
-      - name: AZURE_CLIENT_ID
-        value: <required>
-      - name: AZURE_CLIENT_KEY
-        value: <required>
-      - name: AZURE_TENANT_ID
-        value: <required>
-      - name: AZURE_SUBSCRIPTION_ID
-        value: <required>
-      - name: ACI_RESOURCE_GROUP
-        value: <required>
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: aci-connector
+    spec:
+      containers:
+      - name: aci-connector
+        image: microsoft/aci-connector-k8s:latest
+        imagePullPolicy: Always
+        env:
+        - name: AZURE_CLIENT_ID
+          value: <required>
+        - name: AZURE_CLIENT_KEY
+          value: <required>
+        - name: AZURE_TENANT_ID
+          value: <required>
+        - name: AZURE_SUBSCRIPTION_ID
+          value: <required>
+        - name: ACI_RESOURCE_GROUP
+          value: <required>


### PR DESCRIPTION
Updated the example to use the deployment instead of pod so that aci-connector is always running. 