### PR TITLE
Fixed a file name for a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Edit the `examples/aci-connector.yaml` and input environment variables using the
 $ kubectl create -f examples/aci-connector.yaml 
 deployment "aci-connector" created
 
-s$ kubectl get nodes -w
+$ kubectl get nodes -w
 NAME                        STATUS                     AGE       VERSION
 aci-connector               Ready                      3s        1.6.6
 k8s-agentpool1-31868821-0   Ready                      5d        v1.7.0
 k8s-agentpool1-31868821-1   Ready                      5d        v1.7.0
 k8s-agentpool1-31868821-2   Ready                      5d        v1.7.0
-sk8s-master-31868821-0       Ready,SchedulingDisabled   5d        v1.7.0
+k8s-master-31868821-0       Ready,SchedulingDisabled   5d        v1.7.0
 ```
 
 ### Install the NGINX example

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Edit the `examples/aci-connector.yaml` and input environment variables using the
 $ kubectl create -f examples/aci-connector.yaml 
 deployment "aci-connector" created
 
-$ kubectl get nodes -w
+s$ kubectl get nodes -w
 NAME                        STATUS                     AGE       VERSION
 aci-connector               Ready                      3s        1.6.6
 k8s-agentpool1-31868821-0   Ready                      5d        v1.7.0
 k8s-agentpool1-31868821-1   Ready                      5d        v1.7.0
 k8s-agentpool1-31868821-2   Ready                      5d        v1.7.0
-k8s-master-31868821-0       Ready,SchedulingDisabled   5d        v1.7.0
+sk8s-master-31868821-0       Ready,SchedulingDisabled   5d        v1.7.0
 ```
 
 ### Install the NGINX example
@@ -132,7 +132,7 @@ toleration.
 To use this Pod, you can simply:
 
 ```sh
-$ kubectl create -f examples/nginx-pod-toleration.yaml
+$ kubectl create -f examples/nginx-pod-tolerations.yaml
 ```
 
 Note that if you have other nodes in your cluster then this Pod may not

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Once the connector is registered as a node named `aci-connector`, you can use `n
 
 ## Requirements
 
- 1. A working `az` command-line client
- 2. A Kubernetes cluster with a working `kubectl`
+ 1. A working `az` command-line client - [Install azure cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) 
+ 2. A Kubernetes cluster with a working `kubectl` - [Set up a Kubernetes cluster on Azure](https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-walkthrough)
 
 ## Quickstart
 


### PR DESCRIPTION
I created a k8 connector but the .yaml file name is actually examples/nginx-pod-tolerations.yaml 
not examples/nginx-pod-toleration.yaml . Also added some links


Thanks
