### PR TITLE
Multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM node:8.4.0-alpine
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+
+### Base Image
+# Setup up a base image to use in Build and Runtime images
+FROM node:8.4.0-alpine AS base
 
 WORKDIR /app
-COPY . /app/
+COPY package.json .
 
+### Build Image
+# Installs build dependencies and npm packages
+# Creates artifacts to copy into Runtime image
+FROM base AS build
+
+# Install build OS packages
 RUN set -ex && \
         buildDeps=' \
                 make \
@@ -10,22 +21,33 @@ RUN set -ex && \
                 g++ \
                 python \
                 py-pip \
-        ' && \
-        runDeps=' \
                 curl \
                 openssl \
         ' && \
-   apk add --no-cache \
-       --virtual .build-deps $buildDeps && \
-   apk add --no-cache \
-       --virtual .run-deps $runDeps && \
-   npm install && \
-   npm install --silent --save-dev -g \
-       gulp-cli \
-       typescript && \
-   tsc --target es5 connector.ts && \
-   rm -fr /app/package.json /app/*.ts && \
-   apk del .build-deps
+    apk add --no-cache \
+       --virtual .build-deps $buildDeps
 
+#Copy application into build image
+COPY . .
+
+# Install npm packages
+RUN npm install -g
+RUN npm install --silent --save-dev -g \
+       gulp-cli \
+       typescript
+
+# Compile typescript sources to javascript artifacts
+RUN tsc --target es5 connector.ts
+
+### Runtime Image
+# Copy artifacts from Build image and setups up entrypoint/cmd to run app
+FROM base AS runtime
+
+# Copy artifacts from Build Image
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/*.js ./
+COPY --from=build /app/LICENSE ./
+
+# Runtime command
 ENTRYPOINT ["node"]
 CMD ["connector.js"]


### PR DESCRIPTION
Refactors the `Dockerfile` to use [Docker multi-stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/).

This adds some benefits:

- Easier to read and modify `Dockerfile`
- Better use of layer caching, improving build times and storage

Built image: [ecliptik/aci-connector-k8s:multistage-dockerfile](https://hub.docker.com/r/ecliptik/aci-connector-k8s/)

Image size comparison with original and refactored image:

```
ecliptik/aci-connector-k8s            latest                               8061accee109        18 minutes ago      269MB
ecliptik/aci-connector-k8s            multistage-dockerfile                4abc37a05f52        25 minutes ago      211MB
microsoft/aci-connector-k8s           latest                               a8ffcc196437        7 days ago          753MB
```

Tested image on a 2-node k8s armhf cluster and verified the example nginx pod came up in ACI,

```
$ kubectl get pods -o wide                          
NAME                             READY     STATUS    RESTARTS   AGE       IP              NODE           
aci-connector-4049758742-rjmp1   1/1       Running   0          2m        10.244.1.27     tael           
nginx                            1/1       Running   0          15s       40.83.182.135   aci-connector

$ kubectl describe pod aci-connector-4049758742-rjmp1 | grep "Image:"
    Image:              ecliptik/aci-connector-k8s:alpine-armhf
```