### PR TITLE
fix(chart): remove hardcoded namespace

### DIFF
--- a/charts/aci-connector/templates/deployment.yaml
+++ b/charts/aci-connector/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
-  namespace: default
 spec:
   replicas: 1
   template:

--- a/examples/nginx-pod.yaml
+++ b/examples/nginx-pod.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx
-  namespace: default
 spec:
   containers:
   - image: nginx


### PR DESCRIPTION
Charts should never hardcode namespaces. Namespace is injected by
Helm.

Likewise, there doesn't seem to be a valid reason for hardcoding the "default" namespace into the nginx example, since "by default" kubectl will send the resource to the default namespace, and you can easily override on the CLI with `-n`. If it's hard-coded, you have to edit the YAML to override.