### PR TITLE
feat(chart): add rbac support

### DIFF
--- a/charts/aci-connector/templates/deployment.yaml
+++ b/charts/aci-connector/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      serviceAccountName: "{{ .Values.serviceAccount }}"
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/aci-connector/templates/rbac.yaml
+++ b/charts/aci-connector/templates/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" }}
+apiVersion: v1
+kind: List
+items:
+# ACI Connector Role (cluster wide)
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    name: "aci-connector"
+  rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs:     ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/status"]
+    verbs:     ["get","list","watch","create","patch","update","delete"]
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/status"]
+    verbs:     ["get","list","watch","create","patch","update","delete"]
+# ACI Connector Role Binding (cluster wide)
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: "aci-connector"
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: "aci-connector"
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: "{{ .Values.serviceAccount }}"
+    namespace: "{{ .Release.Namespace }}"
+{{ end }}

--- a/charts/aci-connector/templates/sa.yaml
+++ b/charts/aci-connector/templates/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aci-connector
+

--- a/charts/aci-connector/values.yaml
+++ b/charts/aci-connector/values.yaml
@@ -9,3 +9,4 @@ env:
   azureSubscriptionId:
   aciResourceGroup:
   aciRegion:
+serviceAccount: aci-connector


### PR DESCRIPTION
Adds a `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` to allow the connector to work in RBAC-enabled clusters.  The specific RBAC rules could probably be made more granular.

This has been tested on RBAC clusters, but not yet tested on non-RBAC clusters.